### PR TITLE
fix repository and homepage url

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/joaquimserafim/express-mw-correlation-idd.git"
+    "url": "git+https://github.com/joaquimserafim/express-mw-correlation-id.git"
   },
   "keywords": [
     "express",
@@ -31,7 +31,7 @@
   "bugs": {
     "url": "https://github.com/joaquimserafim/express-mw-correlation-id/issues"
   },
-  "homepage": "https://github.com/joaquimserafim/express-mw-correlation-idd#readme",
+  "homepage": "https://github.com/joaquimserafim/express-mw-correlation-id#readme",
   "devDependencies": {
     "chai": "^3.5.0",
     "express": "^4.14.0",


### PR DESCRIPTION
repository and homepage url on [npmjs.com](https://www.npmjs.com/package/express-mw-correlation-id) are broken, this PR fixes it